### PR TITLE
fix: alvr websocket 400 error

### DIFF
--- a/src/core/ext_tracking/alvr.rs
+++ b/src/core/ext_tracking/alvr.rs
@@ -176,7 +176,9 @@ fn receive_until_err(
     system: &mut sysinfo::System,
 ) -> anyhow::Result<()> {
     const WS_URL: &str = "ws://127.0.0.1:8082/api/events";
-    let Ok(mut ws) = ClientBuilder::new(WS_URL)?.connect_insecure() else {
+    let mut builder = ClientBuilder::new(WS_URL)?;
+    builder.add_header("X-ALVR".to_string(), "true".to_string());
+    let Ok(mut ws) = builder.connect_insecure() else {}
         return Ok(()); // long retry
     };
 

--- a/src/core/ext_tracking/alvr.rs
+++ b/src/core/ext_tracking/alvr.rs
@@ -178,7 +178,7 @@ fn receive_until_err(
     const WS_URL: &str = "ws://127.0.0.1:8082/api/events";
     let mut builder = ClientBuilder::new(WS_URL)?;
     builder.add_header("X-ALVR".to_string(), "true".to_string());
-    let Ok(mut ws) = builder.connect_insecure() else {}
+    let Ok(mut ws) = builder.connect_insecure() else {
         return Ok(()); // long retry
     };
 


### PR DESCRIPTION
Not sure if this was a new change made within ALVR but i noticed that it wasn't working (I'm using version 20.12.1), and when manually navigating to the websocket in a browser i was presented with an error saying "Missing X-ALVR header".

Upon looking at the ALVR side it just wanted this header with a true value, otherwise it was denying it.