### PR TITLE
Fix going cross-eyed with HTC headsets.

### DIFF
--- a/src/core/ext_tracking/htc.rs
+++ b/src/core/ext_tracking/htc.rs
@@ -31,7 +31,7 @@ pub(crate) fn htc_to_unified(d: &HtcFacialData) -> UnifiedShapes {
     );
     shapes.setu(
         UnifiedExpressions::EyeLeftX,
-        d.eyef(xr::EyeExpressionHTC::LEFT_OUT) - d.eyef(xr::EyeExpressionHTC::LEFT_IN),
+        d.eyef(xr::EyeExpressionHTC::LEFT_IN) - d.eyef(xr::EyeExpressionHTC::LEFT_OUT),
     );
     shapes.setu(
         UnifiedExpressions::EyeY,


### PR DESCRIPTION
This fixes an issue found while testing WiVRn/WiVRn#255 that causes the eyes to go in opposite directions when looking left and right on Vive standalone headsets.