### PR TITLE
Update Homebrew Tap URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ chmod +x VrcAdvert oscavmgr
 
 or via Homebrew:
 ```bash
-brew tap shiloh/atomicxr https://codeberg.org/shiloh/homebrew-atomicxr.git
+brew tap matrixfurry.com/atomicxr https://tangled.sh/@matrixfurry.com/homebrew-atomicxr
 brew install vrc-advert
 brew install oscavmgr
 ```


### PR DESCRIPTION
The AtomicXR Homebrew tap was migrated to Tangled as part of the AtomicXR v1 release

I am sorry for adding the tap to this README before it was stable. This version of the tap is stable, and the URL will not change again in the future.