### PR TITLE
added --expose support and nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Simple Rust dev shell";
+
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          rustc
+          cargo
+          rustfmt
+          clippy
+          pkg-config
+          openssl
+          gcc
+          libiconv
+          openxr-loader
+          rust-analyzer
+        ];
+      };
+    };
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -47,6 +47,7 @@ pub struct AppState {
 }
 
 pub struct AvatarOsc {
+    ip: IpAddr,
     osc_port: u16,
     upstream: UdpSocket,
     ext_autopilot: ext_autopilot::ExtAutoPilot,
@@ -67,7 +68,7 @@ pub struct OscTrack {
 
 impl AvatarOsc {
     pub fn new(args: Args, multi: MultiProgress) -> AvatarOsc {
-        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let ip = IpAddr::V4(if args.expose {Ipv4Addr::UNSPECIFIED} else {Ipv4Addr::LOCALHOST});
 
         let upstream = UdpSocket::bind("0.0.0.0:0").expect("bind upstream socket");
         upstream
@@ -81,6 +82,7 @@ impl AvatarOsc {
         let ext_oscjson = ext_oscjson::ExtOscJson::new();
 
         AvatarOsc {
+            ip: ip,
             osc_port: args.osc_port,
             upstream,
             ext_autopilot,
@@ -98,7 +100,7 @@ impl AvatarOsc {
     }
 
     pub fn handle_messages(&mut self) {
-        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        let ip = self.ip;
         let listener =
             UdpSocket::bind(SocketAddr::new(ip, self.osc_port)).expect("bind listener socket");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ pub struct Args {
     #[command(subcommand)]
     face: FaceSetup,
 
+    /// Expose and lisen on 0.0.0.0, instead of localhost
+    #[arg(long, default_value_t = false)]
+    expose: bool,
+
     /// OSC port for VRC
     #[arg(long, default_value = "9000")]
     vrc_port: u16,


### PR DESCRIPTION
Hey, I've got the craziest setup and thus requires that oscavmgr can listen on 0.0.0.0 instead of localhost.
It is because I run Babble and my fork of a competitor ETVR on Docker on my server, in my local network.
Thus saving CPU on my desktop. (I love distributed computing!!!)

<img width="2388" height="1222" alt="image" src="https://github.com/user-attachments/assets/5859fc3c-c3cc-463d-ae52-e5f09991a9e7" />
Here's a flowchart I made a while ago. It is quite outdated. (It has gotten more chaotic now)

Anyways...
## Changes
- Added an "--expose" optional argument, which just switches from localhost to 0.0.0.0 wildcard instead.
- Added a nix flake, for the nix people out there. (I use NixOS btw)

## Note
- This is my third time messing with rust, and I was too lazy to setup syntax highlighting and formatting. Which means that it may require a little bit of code review.
- This is my second time making a nix flake for a project. So I don't think it is up to the nix veterans' standards. But it works ¯\\_(ツ)_/¯